### PR TITLE
Features/ZYB-250

### DIFF
--- a/Database/Objects/Procs/dbo.pPublishAgHubWells.sql
+++ b/Database/Objects/Procs/dbo.pPublishAgHubWells.sql
@@ -79,12 +79,12 @@ begin
 			aws.WellTPID
 	into #agIrrigationUnits
 	from dbo.AgHubWellStaging aws
-	where aws.WellTPID is not null
+	where aws.WellTPID is not null and aws.IrrigationUnitGeometry is not null
 
 	delete ahiu
 	from dbo.AgHubIrrigationUnit ahiu
 	left join #agIrrigationUnits ahiuNew on ahiu.WellTPID = ahiuNew.WellTPID
-	where ahiuNew.WellTPID is null
+	where ahiuNew.WellTPID is null or ahiu.IrrigationUnitGeometry is null
 
 	insert into dbo.AgHubIrrigationUnit (WellTPID, IrrigationUnitGeometry)
 	select ahiuNew.WellTPID,

--- a/Database/ReleaseScript/0075 - Add WaterYears back to 2016.sql
+++ b/Database/ReleaseScript/0075 - Add WaterYears back to 2016.sql
@@ -1,0 +1,44 @@
+create table #new_years
+(
+	[Year] int not null
+)
+
+insert into #new_years ([Year]) 
+select y.WaterYear from
+(
+	select 2016 as WaterYear union 
+	select 2017 union
+	select 2018 union
+	select 2019 union
+	select 2020 union
+	select 2021 union
+	select 2022
+) y 
+left join dbo.WaterYearMonth wym on y.WaterYear = wym.[Year] 
+where wym.WaterYearMonthID is null
+
+go
+
+insert into dbo.WaterYearMonth ([Year], [Month])
+select nwy.[Year], m.MonthNumber
+from #new_years nwy
+cross join 
+(
+    SELECT 1 as MonthNumber UNION 
+    SELECT 2 as MonthNumber UNION 
+    SELECT 3 as MonthNumber UNION 
+    SELECT 4 as MonthNumber UNION 
+    SELECT 5 as MonthNumber UNION 
+    SELECT 6 as MonthNumber UNION 
+    SELECT 7 as MonthNumber UNION 
+    SELECT 8 as MonthNumber UNION 
+    SELECT 9 as MonthNumber UNION 
+    SELECT 10 as MonthNumber UNION 
+    SELECT 11 as MonthNumber UNION 
+    SELECT 12 as MonthNumber
+) m
+left join dbo.WaterYearMonth wym on nwy.[Year] = wym.[Year] and m.MonthNumber = wym.[Month]
+where wym.WaterYearMonthID is null
+order by nwy.[Year], m.MonthNumber
+
+drop table #new_years

--- a/Database/ReleaseScript/0076 - Removing OpenET data for null-geometry irrigation units.sql
+++ b/Database/ReleaseScript/0076 - Removing OpenET data for null-geometry irrigation units.sql
@@ -1,0 +1,10 @@
+	--- clear out ET and precip data for IUs which will be deleted in updated PublishAgHubWells sproc
+	delete ahiuwymed
+	from dbo.AgHubIrrigationUnitWaterYearMonthETDatum ahiuwymed
+	join AgHubIrrigationUnit ahiu on ahiu.AgHubIrrigationUnitID = ahiuwymed.AgHubIrrigationUnitID
+	where ahiu.IrrigationUnitGeometry is null
+
+	delete ahiuwympd
+	from dbo.AgHubIrrigationUnitWaterYearMonthPrecipitationDatum ahiuwympd
+	join AgHubIrrigationUnit ahiu on ahiu.AgHubIrrigationUnitID = ahiuwympd.AgHubIrrigationUnitID
+	where ahiu.IrrigationUnitGeometry is null


### PR DESCRIPTION
Updated PublishAgHubWells to omit null-geometry irrigation units when updating AgHubIrrigationUnit table in nightly job, release script to clear out OpenET data for these null-geometry units prior to removing the units themselves